### PR TITLE
Gooes Particle table name correction

### DIFF
--- a/GOES/Scripts/update_goes_html_page.py
+++ b/GOES/Scripts/update_goes_html_page.py
@@ -341,7 +341,7 @@ def make_intg_table():
     bline = bline + '\t' + '-'*150 +'\n'
     bline = bline + aline
 
-    with open(f"{GOES_DATA_DIR}/Gp_part_5min.txt", 'w') as fo:
+    with open(f"{GOES_DATA_DIR}/Gp_part_5m.txt", 'w') as fo:
         fo.write(bline)
 
     return line


### PR DESCRIPTION
Correct the name of the file for generating the text version of the integral proton and electron table.