### PR TITLE
Ace no valid data alert

### DIFF
--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -23,7 +23,6 @@ ACE_DATA_DIR = "/data/mta4/Space_Weather/ACE/Data" #: Directory for ACE Data.
 HOURS_MISSING = 12 #: Count of consecutive hours missing valid ACE data.
 #: Sporadically valid data might be available. Send alert if number of valid point's doesn't exceed LEEWAY
 LEEWAY = 5
-_ADMIN = "mtadude@cfa.harvard.edu" #: Admin email address
 _ALERT = "sot_ace_alert@cfa.harvard.edu" #: Alert email address
 _INPUT_ACE_COLUMNS = [
     "year",
@@ -150,15 +149,9 @@ if __name__ == "__main__":
     parser.add_argument("-m", "--mode", choices = ['flight','test'], required = True, help = "Determine running mode.")
     parser.add_argument("-p", "--path", required = False, help = "Directory path to determine input data location.")
     args = parser.parse_args()
-#
-#--- Determine if running in test mode and change pathing if so
-#
+
     if args.mode == "test":
-        print("Running In Test Mode.")
-        TESTMAIL = True
-#
-#--- Path output to same location as unit tests
-#
+        _TESTMAIL = True
         if args.path:
             ACE_DATA_DIR = args.path
         else:
@@ -166,9 +159,8 @@ if __name__ == "__main__":
         TMP_DIR = f"{os.getcwd()}/test/_outTest"
         os.makedirs(f"{ACE_DATA_DIR}", exist_ok = True)
         os.makedirs(f"{TMP_DIR}", exist_ok = True)
-        print(f"ACE_DATA_DIR: {ACE_DATA_DIR}")
-        print(f"TMP_DIR: {TMP_DIR}")
-        check_viol()
+
+        ace_viol()
 
     elif args.mode == "flight":
 #
@@ -181,7 +173,7 @@ if __name__ == "__main__":
             sys.exit(f"Lock file exists as /tmp/{user}/{name}.lock. Process already running/errored out. Check calling scripts/cronjob/cronlog.")
         else:
             os.system(f"mkdir -p /tmp/{user}; touch /tmp/{user}/{name}.lock")
-        check_viol()
+        ace_viol()
 #
 #--- Remove lock file once process is completed
 #

--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -1,11 +1,51 @@
 #!/proj/sot/ska3/flight/bin/python
+"""
+**ace_viol.py**: Alert if no recently valid ACE data
+
+:Author: W. Aaron (william.aaron@cfa.harvard.edu)
+:Last Updated: Mar 03, 2025
+
+"""
 import os
 import sys
+from email.mime.text import MIMEText
+from subprocess import Popen, PIPE
+from astropy.io import ascii
+from cxotime import CxoTime
+from datetime import timedelta
 import argparse
 #
 #--- Define Globals
 #
-ACE_DATA_DIR = "/data/mta4/Space_Weather/ACE/Data"
+ACE_DATA_DIR = "/data/mta4/Space_Weather/ACE/Data" #: Directory for ACE Data.
+HOURS_IN_VIOLATION = 12 #: Count of consecutive hours without valid ACE data.
+#: Sporadically valid data might be available. Send alert if number of valid point's doesn't exceed LEEWAY
+LEEWAY = 5
+_ADMIN = "mtadude@cfa.harvard.edu" #: Admin email address
+_ALERT = "sot_ace_alert@cfa.harvard.edu" #: Alert email address
+_INPUT_ACE_COLUMNS = [
+    "year",
+    "month",
+    "day",
+    "hhmm",
+    "mjd",
+    "daysecs",
+    "electron_status",
+    "electron38-53",
+    "electron175-315",
+    "proton_status",
+    "proton47-68",
+    "proton115-195",
+    "proton310-580",
+    "proton795-1193",
+    "proton1060-1900",
+    "aniso",
+]  #: For reading in ACE data file with astropy.io.ascii.
+_DEFAULT_VIOLATION = {
+    "no_valid_ace": {"cxotime": 0, "val": False}
+}  #: If cannot find file of previous violations, then assume issue involving them not being sent and rebuild file. Built for multiple alert types.
+
+
 TESTMAIL = False
 VIOL_HOUR = 8
 ARCHIVE_LENGTH_LIM = 12 * VIOL_HOUR

--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -95,9 +95,7 @@ def send_mail(subject, recipients, text_body, cc=""):
     :param cc:Carbon Copy recipients, defaults to ''
     :type cc: str or list, optional
     """
-    #
-    # --- Construct message in MIMEText
-    #
+    #: Construct message in MIMEText
     msg = MIMEText(text_body)
     msg["Subject"] = subject
     if type(recipients).__name__ == "list":
@@ -106,69 +104,46 @@ def send_mail(subject, recipients, text_body, cc=""):
         cc = ",".join(cc)
     msg["To"] = recipients
     msg["CC"] = cc
-    #
-    # --- Send Email
-    #
     if not _TESTMAIL:
         p = Popen(["/sbin/sendmail", "-t", "-oi"], stdin=PIPE)
         (out, error) = p.communicate(msg.as_bytes())
     else:
         print(msg)
 
-def check_viol():
+def ace_viol():
     """
-    Emails admins alert if ace data invalid for period of time
-
-    input:	<ace_dir>/Data/ace_12h_archive
-        <ace_dir>/Data/ace.archive
-    output:	Admin Email
-        /tmp/mta/ace_viol.out
+    Iterate over the ACE data table to check counts of missing data.
+    
+    proton_status column has three markers
+        - 0:  Valid Data
+        - -1: Missing Data
+        - 9:  Unidentified invalid channel
     """
-    ifile = f"{ACE_DATA_DIR}/ace_12h_archive"
-    if not os.path.isfile(ifile):
-        content = f"Error: {ifile} not found\n"
-        content += f"by script {__file__}.\n"
-        content += f"Alerts depend on this file. Please Investigate.\n"
-        content += f"This message was sent to {ADMIN}"
-        send_mail("Missing ACE archive",content, ADMIN)
-    else:
-        with open(f"{ACE_DATA_DIR}/ace_12h_archive") as f:
-            file_data = [line.strip() for line in f.readlines() if line != '']
-            file_data.reverse()
-#
-#--- Check only the time subsection of data which corresponds to
-#--- an ARCHIVE_LENGTH_LIM number of 5-min increments
-#
-        data = [line.split() for line in file_data[:ARCHIVE_LENGTH_LIM]]
-#
-#--- If the entire data set is invalid, then email alert, otherwise proceed as normal
-#
-        valid_marker = False
-        for entry in data:
-            if (entry[6] == "0" or entry[9] == "0"):
-                valid_marker = True
-                break
-        if not valid_marker:
+    ace_table = _read_ace_file()
+    #: Slice table to search for consecutive data points for a set
+    #: number of hours ago. Number of hours is HOURS_MISSING variable.
+    _start = ace_table['cxotime'][-1] - timedelta(hours=HOURS_MISSING)
+    ace_table = ace_table[ace_table['cxotime'] >= _start]
+    
+    #: Select missing table values.
+    missing_selection = ace_table['proton_status'] == -1
+    #: If all consecutive data points minus the LEEWAY are less than those missing,
+    #: then check for sending notification.
+    if len(ace_table) - LEEWAY <= sum(missing_selection):
+        if 8 <= _NOW.hour <= 22:
+            #: Between 8 am and 10 pm, send alert
             lockfile = f"{TMP_DIR}/ace_viol.out"
-            if (os.path.exists(lockfile)):
+            if os.path.isfile(lockfile):
+                #: Notification already sent.
                 os.system(f'date >> {lockfile}')
             else:
-                content = f'Alert Trigger Script: {__file__} \n'
-                content += f'Alert in file: {ifile}\n'
-                content += f'No valid ACE data for at least {VIOL_HOUR} hours.\n'
-                content += f"Radiation team should investigate.\n"
-                content += f"This message was sent to {ALERT}\n"
-                send_mail(f"ACE no valid data for >{VIOL_HOUR}h", content, ALERT)
-                os.system(f"cp {ifile} {lockfile}")
-
-def send_mail(subject, content, address):
-    if TESTMAIL:
-        print(f"Test Mode, interrupting following email.\n\
-              Subject: {subject}\n\
-              Address: {address}\n\
-              Content: {content}\n")
-    else:
-        os.system(f"echo '{content}' | mailx -s '{subject}' {address}")
+                text_body = f'Alert Trigger Script: {__file__}\n'
+                text_body += f'Alert in file: {ACE_DATA_DIR}/ace_12h_archive\n'
+                text_body += f'No valid ACE data for at least {HOURS_MISSING} hours.\n'
+                text_body += "Radiation team should investigate.\n"
+                text_body += f"This message was sent to {_ALERT}\n"
+                send_mail(f"ACE no valid data for >{HOURS_MISSING}h", _ALERT, text_body)
+                os.system(f"cp {ACE_DATA_DIR}/ace_12h_archive {lockfile}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 from subprocess import Popen, PIPE
 from astropy.io import ascii
 from cxotime import CxoTime
-from datetime import  datetime, timedelta
+from datetime import timedelta
 import numpy as np
 import argparse
 #
@@ -62,12 +62,11 @@ def _convert_time_format(year, month, day, hhmm):
     :rtype: ``numpy.ndarray(dtype = 'object')``
 
     """
-    hh = hhmm // 100  #: hours in hundreds and thousands place
-    mm = hhmm % 100  #: minutes in tens and ones place
-    time = datetime.strptime(
-        f"{year:04}:{month:02}:{day:02}:{hh:02}:{mm:02}", "%Y:%m:%d:%H:%M"
-    )
-    return CxoTime(time, format="datetime")
+    hh = hhmm // 100  #: Hours in hundreds and thousands place.
+    mm = hhmm % 100  #: Minutes in tens and ones place.
+    #: CxoTime accepts ISOT format
+    time = f"{year:04}-{month:02}-{day:02}T{hh:02}:{mm:02}:00"
+    return CxoTime(time)
 
 def check_viol():
     """

--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -11,6 +11,7 @@ import sys
 from email.mime.text import MIMEText
 from subprocess import Popen, PIPE
 from astropy.io import ascii
+from astropy.table import Column, unique
 from cxotime import CxoTime
 from datetime import timedelta
 import numpy as np
@@ -45,6 +46,19 @@ _INPUT_ACE_COLUMNS = [
 _DEFAULT_VIOLATION = {
     "no_valid_ace": {"cxotime": 0, "val": False}
 }  #: If cannot find file of previous violations, then assume issue involving them not being sent and rebuild file. Built for multiple alert types.
+
+def _read_ace_file():
+    
+    data_file = f"{ACE_DATA_DIR}/ace_12h_archive"
+    ace_table = unique(ascii.read(data_file,names=_INPUT_ACE_COLUMNS))
+    cxotime_col = Column(
+        _convert_time_format(
+            ace_table["year"], ace_table["month"], ace_table["day"], ace_table["hhmm"]
+        ),
+        name="cxotime",
+    )
+    ace_table.add_column(cxotime_col)
+    return ace_table
 
 @np.vectorize
 def _convert_time_format(year, month, day, hhmm):

--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -1,6 +1,6 @@
 #!/proj/sot/ska3/flight/bin/python
 """
-**ace_viol.py**: Alert if no recently valid ACE data
+**ace_viol.py**: Alert if missing too much ACE data.
 
 :Author: W. Aaron (william.aaron@cfa.harvard.edu)
 :Last Updated: Mar 03, 2025
@@ -13,14 +13,14 @@ from subprocess import Popen, PIPE
 from astropy.io import ascii
 from astropy.table import Column, unique
 from cxotime import CxoTime
-from datetime import timedelta
+from datetime import datetime, timedelta
 import numpy as np
 import argparse
 #
 #--- Define Globals
 #
 ACE_DATA_DIR = "/data/mta4/Space_Weather/ACE/Data" #: Directory for ACE Data.
-HOURS_IN_VIOLATION = 12 #: Count of consecutive hours without valid ACE data.
+HOURS_MISSING = 12 #: Count of consecutive hours missing valid ACE data.
 #: Sporadically valid data might be available. Send alert if number of valid point's doesn't exceed LEEWAY
 LEEWAY = 5
 _ADMIN = "mtadude@cfa.harvard.edu" #: Admin email address
@@ -43,12 +43,13 @@ _INPUT_ACE_COLUMNS = [
     "proton1060-1900",
     "aniso",
 ]  #: For reading in ACE data file with astropy.io.ascii.
-_DEFAULT_VIOLATION = {
-    "no_valid_ace": {"cxotime": 0, "val": False}
-}  #: If cannot find file of previous violations, then assume issue involving them not being sent and rebuild file. Built for multiple alert types.
+_TESTMAIL = False #: Boolean to test mail
+_NOW = datetime.now()
 
 def _read_ace_file():
-    
+    """
+    Read in the ACE Data file and format into astropy table.
+    """
     data_file = f"{ACE_DATA_DIR}/ace_12h_archive"
     ace_table = unique(ascii.read(data_file,names=_INPUT_ACE_COLUMNS))
     cxotime_col = Column(
@@ -81,6 +82,38 @@ def _convert_time_format(year, month, day, hhmm):
     #: CxoTime accepts ISOT format
     time = f"{year:04}-{month:02}-{day:02}T{hh:02}:{mm:02}:00"
     return CxoTime(time)
+
+def send_mail(subject, recipients, text_body, cc=""):
+    """Send MIMEText Email
+
+    :param subject: Subject of email
+    :type subject: str
+    :param recipients: Intended recipients
+    :type recipients: list or str
+    :param text_body:Email contents
+    :type text_body: str
+    :param cc:Carbon Copy recipients, defaults to ''
+    :type cc: str or list, optional
+    """
+    #
+    # --- Construct message in MIMEText
+    #
+    msg = MIMEText(text_body)
+    msg["Subject"] = subject
+    if type(recipients).__name__ == "list":
+        recipients = ",".join(recipients)
+    if type(cc).__name__ == "list":
+        cc = ",".join(cc)
+    msg["To"] = recipients
+    msg["CC"] = cc
+    #
+    # --- Send Email
+    #
+    if not _TESTMAIL:
+        p = Popen(["/sbin/sendmail", "-t", "-oi"], stdin=PIPE)
+        (out, error) = p.communicate(msg.as_bytes())
+    else:
+        print(msg)
 
 def check_viol():
     """

--- a/ACE/Scripts/ace_viol.py
+++ b/ACE/Scripts/ace_viol.py
@@ -12,7 +12,8 @@ from email.mime.text import MIMEText
 from subprocess import Popen, PIPE
 from astropy.io import ascii
 from cxotime import CxoTime
-from datetime import timedelta
+from datetime import  datetime, timedelta
+import numpy as np
 import argparse
 #
 #--- Define Globals
@@ -45,13 +46,28 @@ _DEFAULT_VIOLATION = {
     "no_valid_ace": {"cxotime": 0, "val": False}
 }  #: If cannot find file of previous violations, then assume issue involving them not being sent and rebuild file. Built for multiple alert types.
 
+@np.vectorize
+def _convert_time_format(year, month, day, hhmm):
+    """Converts separated ``numpy.ndarray`` containing date information into an array of ``CxoTime`` objects.
 
-TESTMAIL = False
-VIOL_HOUR = 8
-ARCHIVE_LENGTH_LIM = 12 * VIOL_HOUR
-ADMIN = 'mtadude@cfa.harvard.edu'
-ALERT = 'sot_ace_alert@cfa.harvard.edu'
-TMP_DIR = "/tmp/mta"
+    :param year: Four digit year
+    :type year: int
+    :param month: Month
+    :type month: int
+    :param day: Day
+    :type day: int
+    :param hhmm: Integer Combining Hours and Minutes
+    :type hhmm: int
+    :return: ``numpy.ndarray`` of ``CxoTime`` objects.
+    :rtype: ``numpy.ndarray(dtype = 'object')``
+
+    """
+    hh = hhmm // 100  #: hours in hundreds and thousands place
+    mm = hhmm % 100  #: minutes in tens and ones place
+    time = datetime.strptime(
+        f"{year:04}:{month:02}:{day:02}:{hh:02}:{mm:02}", "%Y:%m:%d:%H:%M"
+    )
+    return CxoTime(time, format="datetime")
 
 def check_viol():
     """


### PR DESCRIPTION
Updates to the ACE missing data notification in order to bring the alert in line with the following requirements
- Written to MTA Coding Standard
- Uses ace_alert.py script conventions.
- Implement blackout hours such that no notification is sent between 10pm and 8am eastern time.