### PR TITLE
Space Weather README's updates to RADIATION web pathing instead of RADIATION_new

### DIFF
--- a/ACIS_Rad/Scripts/README
+++ b/ACIS_Rad/Scripts/README
@@ -68,7 +68,7 @@ yearly_template
 Output
 ++++++
 
-Directory:      /data/mta4/www/RADIATION_new/ACIS_Rad/Plots/
+Directory:      /data/mta4/www/RADIATION/ACIS_Rad/Plots/
 
 rad_cnts_curr.png
 rad_use_curr.png
@@ -76,13 +76,13 @@ rad_cnts_<mmyy>.png
 rad_use_<mmyy>.png
 Note: older plots are in gif format.
 
-Directory:  /data/mta4/www/RADIATION_new/ACIS_Rad/Html/
+Directory:  /data/mta4/www/RADIATION/ACIS_Rad/Html/
 
 all<yy>.html
 <mmyy>.html
 rad_time_<mmyy>.html
 
-Directory:  /data/mta4/www/RADIATION_new/ACIS_Rad/
+Directory:  /data/mta4/www/RADIATION/ACIS_Rad/
 
 index.html
 

--- a/Doc/README
+++ b/Doc/README
@@ -52,8 +52,8 @@ Current Directory Paths
 '/data/mta4/Space_Weather/MTA_Rad/'         : mta_dir
 '/data/mta4/Space_Weather/ACIS_Rad/'        : acis_dir
 '/data/mta4/Space_Weather/XMM/'             : xmm_dir
-'/data/mta4/www/RADIATION_new/'             : html_dir
-'cxc.cfa.harvard.edu/mta/RADIATION_new/'    : main_web
+'/data/mta4/www/RADIATION/'             : html_dir
+'cxc.cfa.harvard.edu/mta/RADIATION/'    : main_web
 'ftp.swpc.noaa.gov/pub/lists/'              : noaa_ftp
 'ftp.swpc.noaa.gov/pub/lists/ace/'          : ace_ftp
 'services.swpc.noaa.gov/'                   : noaa_site
@@ -67,8 +67,8 @@ Current Directory Paths
 Web Directory
 #############
 
-Html:               http://cxc.cfa.harvard.edu/mta/RADIATION_new/index.html
-Physical Location:  /data/mta4/www/RADIATION_new/
+Html:               http://cxc.cfa.harvard.edu/mta/RADIATION/index.html
+Physical Location:  /data/mta4/www/RADIATION/
 
 
 

--- a/GSM_plots/Scripts/README
+++ b/GSM_plots/Scripts/README
@@ -29,7 +29,7 @@ output: <html_dir>/Orbit/Plots/GSM.png
 
 
 web page:
-    cxc.cfa.harvard.edu/mta/RADIATION_new/Orbit/orbit.html (top four plots)
+    cxc.cfa.harvard.edu/mta/RADIATION/Orbit/orbit.html (top four plots)
 
 
 cronjob:

--- a/README
+++ b/README
@@ -52,8 +52,8 @@ Current Directory Paths
 '/data/mta4/Space_Weather/MTA_Rad/'         : mta_dir
 '/data/mta4/Space_Weather/ACIS_Rad/'        : acis_dir
 '/data/mta4/Space_Weather/XMM/'             : xmm_dir
-'/data/mta4/www/RADIATION_new/'             : html_dir
-'cxc.cfa.harvard.edu/mta/RADIATION_new/'    : main_web
+'/data/mta4/www/RADIATION/'             : html_dir
+'cxc.cfa.harvard.edu/mta/RADIATION/'    : main_web
 'ftp.swpc.noaa.gov/pub/lists/'              : noaa_ftp
 'ftp.swpc.noaa.gov/pub/lists/ace/'          : ace_ftp
 'services.swpc.noaa.gov/'                   : noaa_site
@@ -67,8 +67,8 @@ Current Directory Paths
 Web Directory
 #############
 
-Html:               http://cxc.cfa.harvard.edu/mta/RADIATION_new/index.html
-Physical Location:  /data/mta4/www/RADIATION_new/
+Html:               http://cxc.cfa.harvard.edu/mta/RADIATION/index.html
+Physical Location:  /data/mta4/www/RADIATION/
 
 
 

--- a/SOHO/Scripts/README
+++ b/SOHO/Scripts/README
@@ -20,7 +20,7 @@ input:  ftp://ftp.swpc.noaa.gov/pub/lists/ace2/*ace_swepam_1h.txt
 output: <html_dir>/Orbit/Plots/solwin.png
 
 Web address:
-https://cxc.cfa.harvard.edu/mta/RADIATION_new/Orbit/orbit.html
+https://cxc.cfa.harvard.edu/mta/RADIATION/Orbit/orbit.html
 
 cron job
 --------

--- a/STEREO/Scripts/README
+++ b/STEREO/Scripts/README
@@ -29,7 +29,7 @@ Output:
 
 web address:
 ------------
-https://cxc.cfa.harvard.edu/mta/RADIATION_new/STEREO/stereo.html
+https://cxc.cfa.harvard.edu/mta/RADIATION/STEREO/stereo.html
 
 Note: stereo B is not working any more and we dropped the data from appearing.
 

--- a/XMM/Scripts/README
+++ b/XMM/Scripts/README
@@ -3,14 +3,14 @@ REALTIME XMM-NEWTON RADIATION OBSERVATIONS
 ##########################################
 
 This directory holds scripts related to XMM real time radiation observation
-page http://cxc.cfa.harvard.edu/mta/RADIATION_new/XMM/index.html.
+page http://cxc.cfa.harvard.edu/mta/RADIATION/XMM/index.html.
 
 Directory:
 ==========
 tle_dir  = /data/mta4/Space_Weather/TLE/
 xmm_dir  = /data/mta4/Space_Weather/XMM/
 data_dir = <xmm_dir>/Data
-web_dir  = /data/mta4/www/RADIATION_new/XMM/
+web_dir  = /data/mta4/www/RADIATION/XMM/
 
 Scripts:
 ========


### PR DESCRIPTION
Update all separated Space_Weather README's with the RADIATION web pathing instead of RADIATION_new.

As this is all documentation text files, testing on script sets have not been performed.