### PR TITLE
Update ImageMagick commands ver 6.9.13 -> ver 7.1.1

### DIFF
--- a/GSM_plots/Scripts/gsm_main_script
+++ b/GSM_plots/Scripts/gsm_main_script
@@ -4,9 +4,9 @@ cd /data/mta4/Space_Weather/GSM_plots/Scripts/
 /data/mta4/Space_Weather/GSM_plots/Scripts/create_lon_and_lat_orbit_plot.py
 
 
-convert /data/mta4/www/RADIATION/Orbit/Plots/GSMORBIT.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSMORBIT.png
-convert /data/mta4/www/RADIATION/Orbit/Plots/GSEORBIT.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSEORBIT.png
-convert /data/mta4/www/RADIATION/Orbit/Plots/GSM.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSM.png
-convert /data/mta4/www/RADIATION/Orbit/Plots/GSE.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSE.png
+magick /data/mta4/www/RADIATION/Orbit/Plots/GSMORBIT.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSMORBIT.png
+magick /data/mta4/www/RADIATION/Orbit/Plots/GSEORBIT.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSEORBIT.png
+magick /data/mta4/www/RADIATION/Orbit/Plots/GSM.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSM.png
+magick /data/mta4/www/RADIATION/Orbit/Plots/GSE.png -trim /data/mta4/www/RADIATION/Orbit/Plots/GSE.png
 
 

--- a/XMM/Scripts/xmm_main_script
+++ b/XMM/Scripts/xmm_main_script
@@ -9,10 +9,10 @@ cd  /data/mta4/Space_Weather/XMM/Scripts
 /data/mta4/Space_Weather/XMM/Scripts/plot_xmm_cxo_comp.py
 /data/mta4/Space_Weather/XMM/Scripts/plot_xmm_rad.py
 
-convert /data/mta4/www/RADIATION/XMM/Plots/mta_plot_xmm_comp.png    -trim /data/mta4/www/RADIATION/XMM/Plots/mta_plot_xmm_comp.png
-convert /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm.png     -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm.png
-convert /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm_xz.png  -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm_xz.png
-convert /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p1.png      -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p1.png
-convert /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p2.png      -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p2.png
+magick /data/mta4/www/RADIATION/XMM/Plots/mta_plot_xmm_comp.png    -trim /data/mta4/www/RADIATION/XMM/Plots/mta_plot_xmm_comp.png
+magick /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm.png     -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm.png
+magick /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm_xz.png  -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_gsm_xz.png
+magick /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p1.png      -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p1.png
+magick /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p2.png      -trim /data/mta4/www/RADIATION/XMM/Plots/mta_xmm_plot_p2.png
 
 


### PR DESCRIPTION
This updates the CLI usage for the ImageMagick software in preparation of the Rocky Linux 10 migration.